### PR TITLE
Do not require an open connection for MySQL string escaping

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -887,11 +887,11 @@ RSpec.describe Mysql2::Client do
       end.not_to raise_error
     end
 
-    it "should require an open connection" do
+    it "should not require an open connection" do
       @client.close
       expect do
         @client.escape ""
-      end.to raise_error(Mysql2::Error)
+      end.not_to raise_error
     end
 
     context 'when mysql encoding is not utf8' do


### PR DESCRIPTION
The detection of closed connections was made more robust by https://github.com/brianmario/mysql2/pull/1022. As a result, in situations where the connection was _actually_ closed, calls to `rb_mysql_client_real_escape` are now raising an exception when they would not have before. 

This modifies the behaviour of the mysql2 gem to not require an open connection to perform an underlying call to `mysql_real_escape_string`. This is effectively emulating the same behaviour as before https://github.com/brianmario/mysql2/pull/1022. 

I tried to write a test for the negative case that would raise when we haven't connected at least once. I could not come up with a way to create a `Mysql2::Client` instance without performing a successful `connect`.
